### PR TITLE
updating dependencies to match psc-0.11.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,13 +19,13 @@
     "output"
   ],
   "dependencies": {
-    "purescript-monoid": "^2.0.0",
-    "purescript-maps": "^2.0.0",
-    "purescript-strings": "^2.0.1",
-    "purescript-catenable-lists": "^3.0.0",
-    "purescript-tuples": "^3.0.0"
+    "purescript-monoid": "^3.0.0",
+    "purescript-maps": "^3.0.0",
+    "purescript-strings": "^3.0.0",
+    "purescript-catenable-lists": "^4.0.0",
+    "purescript-tuples": "^4.0.0"
   },
   "devDependencies": {
-    "purescript-console": "^2.0.0"
+    "purescript-console": "^3.0.0"
   }
 }

--- a/psc-package.json
+++ b/psc-package.json
@@ -1,6 +1,6 @@
 {
     "name": "purescript-smolder",
-    "set": "psc-0.10.4",
+    "set": "psc-0.11.1",
     "source": "https://github.com/purescript/package-sets.git",
     "depends": [
         "tuples",


### PR DESCRIPTION
Running the tests gives:

```
➜  purescript-smolder git:(master) pulp test
* Building project in /home/suppi/code/purescript/purescript-smolder
* Build successful.
* Running tests...
<html lang="en"><head><meta charset="utf-8"/><meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/><title>OMG HAI LOL</title><meta name="description" content="YES OMG HAI LOL&quot;&gt;&lt;script&gt;alert(&quot;lol pwned&quot;);&lt;&#x2F;script&gt;"/><meta name="viewport" content="width=device-width"/><link rel="stylesheet" href="css&#x2F;screen.css"/></head><body><h1>OMG HAI LOL</h1><p>This is clearly the best HTML DSL ever invented.&lt;script&gt;alert(&quot;lol pwned&quot;);&lt;&#x2F;script&gt;</p></body></html>
* Tests OK.
```

Thanks!