### PR TITLE
Escaping entities

### DIFF
--- a/src/Text/Smolder/Renderer/String.purs
+++ b/src/Text/Smolder/Renderer/String.purs
@@ -39,7 +39,7 @@ renderItem :: ∀ e. MarkupM e ~> State String
 renderItem (Element name children attrs _ rest) =
   let c = render children
       b = "<" <> name <> showAttrs attrs <>
-          (if length c > 0
+          (if length c > 0 || name == "script"
            then ">" <> c <> "</" <> name <> ">"
            else "/>")
   in state \s → Tuple rest $ append s b

--- a/src/Text/Smolder/Renderer/String.purs
+++ b/src/Text/Smolder/Renderer/String.purs
@@ -4,34 +4,38 @@ module Text.Smolder.Renderer.String
 
 import Prelude
 
+import Control.Comonad (extend)
+import Control.Comonad.Cofree (Cofree, head, mkCofree, tail, (:<))
 import Control.Monad.Free (foldFree)
-import Control.Monad.State (execState, State, state)
+import Control.Monad.State (State, evalState, execState, get, put, state)
+import Data.Array ((..))
 import Data.CatList (CatList)
-import Data.Foldable (fold)
-import Data.Maybe (fromMaybe)
-import Data.StrMap (StrMap, fromFoldable, lookup)
-import Data.String (Pattern(Pattern), joinWith, length, split)
+import Data.Char (toCharCode)
+import Data.Foldable (elem, fold, foldr)
+import Data.Map (Map, lookup, fromFoldable)
+import Data.Maybe (Maybe(..), fromMaybe)
+import Data.String (fromCharArray, length, toCharArray)
 import Data.Tuple (Tuple(..))
 import Data.Tuple.Nested ((/\))
 import Global (encodeURI)
 import Text.Smolder.Markup (Attr(..), Markup, MarkupM(..))
 
-escapeMap :: StrMap String
+escapeMap :: Map Char String
 escapeMap = fromFoldable
-  [ "&" /\ "&amp;"
-  , "<" /\ "&lt;"
-  , ">" /\ "&gt;"
-  , "\"" /\ "&quot;"
-  , "'" /\ "&#39;"
-  , "/" /\ "&#x2F;"
+  [ '&' /\ "&amp;"
+  , '<' /\ "&lt;"
+  , '>' /\ "&gt;"
+  , '"' /\ "&quot;"
+  , '\'' /\ "&#39;"
+  , '/' /\ "&#x2F;"
   ]
 
-escapeMIMEMap :: StrMap String
+escapeMIMEMap :: Map Char String
 escapeMIMEMap = fromFoldable
-  [ "&" /\ "&amp;"
-  , "<" /\ "&lt;"
-  , "\"" /\ "&quot;"
-  , "'" /\ "&#39;"
+  [ '&' /\ "&amp;"
+  , '<' /\ "&lt;"
+  , '"' /\ "&quot;"
+  , '\'' /\ "&#39;"
   ]
 
 isMIMEAttr :: String -> String -> Boolean
@@ -67,11 +71,47 @@ isURLAttr tag attr
   | attr == "poster" && tag == "video" = true
   | otherwise = false
 
-escape :: StrMap String -> String -> String
-escape m s = joinWith "" (escapeChar <$> (split (Pattern "") s))
+toStream :: String -> Cofree Maybe Char
+toStream s = foldr (\c t -> c :< (Just t)) (mkCofree '\0' Nothing) cs
   where
-    escapeChar :: String -> String
-    escapeChar c = fromMaybe c $ lookup c m
+  cs = toCharArray s
+
+fromStream :: Cofree Maybe String -> String
+fromStream cof =
+  case (head cof), (tail cof) of
+    _, Nothing -> ""
+    s, (Just cof') -> s <> fromStream cof'
+
+escape :: Map Char String -> String -> String
+escape m = fromStream <<< extend escapeS <<< toStream
+  where
+    startsEntity :: Maybe (Cofree Maybe Char) -> Boolean
+    startsEntity (Just w) =
+              case head w, tail w of
+                '#',  Just w' -> checkTail (48..57) w'
+                '#',  Nothing -> false
+                _,    _       -> checkTail (65..90 <> 97..122) w 
+    startsEntity Nothing = false
+
+    checkTail :: Array Int -> Cofree Maybe Char -> Boolean
+    checkTail allowed = flip evalState false <<< checkTail'
+      where
+        -- keep if `;` is allowed in `State` monad
+        checkTail' :: Cofree Maybe Char -> State Boolean Boolean
+        checkTail' w =
+          case toCharCode $ head w of
+            cc  | cc `elem` allowed -> do
+              put true
+              fromMaybe (pure false) $ checkTail' <$> tail w
+                | cc == 59 -> get
+                | otherwise -> pure false
+
+    escapeS :: Cofree Maybe Char -> String
+    escapeS w =
+      case head w of
+        '&' | startsEntity (tail w) -> "&"
+            | otherwise             -> "&amp;"
+        c                           -> fromMaybe (fromCharArray [c]) $ lookup c m
 
 escapeAttrValue :: String -> String -> String -> String
 escapeAttrValue tag key value

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,16 +1,16 @@
 module Test.Main where
 
-import Prelude
+import Prelude hiding (div)
 
 import Control.Monad.Aff.AVar (AVAR)
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Console (CONSOLE, log)
 import Test.SVG as SvgTest
-import Test.Unit (test)
+import Test.Unit (suite, test)
 import Test.Unit.Assert (equal)
 import Test.Unit.Console (TESTOUTPUT)
 import Test.Unit.Main (runTest)
-import Text.Smolder.HTML (body, h1, head, html, img, link, meta, p, script, style, title)
+import Text.Smolder.HTML (body, div, h1, head, html, img, link, meta, p, script, style, title)
 import Text.Smolder.HTML.Attributes (charset, content, href, httpEquiv, lang, name, rel, src, type')
 import Text.Smolder.Markup (Markup, on, text, (!), (#!))
 import Text.Smolder.Renderer.String (render)
@@ -38,4 +38,18 @@ main :: Eff (console :: CONSOLE, avar :: AVAR, testOutput :: TESTOUTPUT) Unit
 main = runTest do
   test "render HTML to string" do
     equal expected $ render doc
+  suite "escaping entities" do
+    test "allow string entities" do
+      equal "<div>&hearts;</div>" $ render $ div $ text "&hearts;"
+    test "allow numeric entities" do
+      equal "<div>&#39;</div>" $ render $ div $ text "&#39;"
+    test "escape &" do
+      equal "<div>&amp;</div>" $ render $ div $ text "&"
+      equal "<div>&amp;gt.</div>" $ render $ div $ text "&gt."
+      equal "<div>&amp;#.</div>" $ render $ div $ text "&#."
+      equal "<div>&amp;#;</div>" $ render $ div $ text "&#;"
+    test "quirks" do
+      -- this renders invalid HTML
+      equal "<div>&#1;</div>" $ render $ div $ text "&#1;"
+      equal "<div>&abc;</div>" $ render $ div $ text "&abc;"
   SvgTest.tests

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,18 +1,18 @@
 module Test.Main where
 
-import Test.SVG as SvgTest
-
 import Prelude
+
 import Control.Monad.Aff.AVar (AVAR)
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Console (CONSOLE, log)
+import Test.SVG as SvgTest
 import Test.Unit (test)
 import Test.Unit.Assert (equal)
 import Test.Unit.Console (TESTOUTPUT)
 import Test.Unit.Main (runTest)
-import Text.Smolder.HTML (html, head, meta, link, title, body, h1, p)
-import Text.Smolder.HTML.Attributes (lang, charset, httpEquiv, content, name, rel, href)
-import Text.Smolder.Markup (on, (#!), Markup, text, (!))
+import Text.Smolder.HTML (body, h1, head, html, link, meta, p, script, title)
+import Text.Smolder.HTML.Attributes (charset, content, href, httpEquiv, lang, name, rel, src)
+import Text.Smolder.Markup (Markup, on, text, (!), (#!))
 import Text.Smolder.Renderer.String (render)
 
 doc :: forall a e. Markup (a -> Eff (console :: CONSOLE | e) Unit)
@@ -24,12 +24,13 @@ doc = html ! lang "en" $ do
     meta ! name "description" ! content "YES OMG HAI LOL\"><script>alert(\"lol pwned\");</script>"
     meta ! name "viewport" ! content "width=device-width"
     link ! rel "stylesheet" ! href "css/screen.css"
+    script ! src "index.js" $ text ""
   body $ do
     h1 #! on "click" (\_ -> log "click") $ text "OMG HAI LOL"
     p $ text "This is clearly the best HTML DSL ever invented.<script>alert(\"lol pwned\");</script>"
 
 expected :: String
-expected = """<html lang="en"><head><meta charset="utf-8"/><meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/><title>OMG HAI LOL</title><meta name="description" content="YES OMG HAI LOL&quot;&gt;&lt;script&gt;alert(&quot;lol pwned&quot;);&lt;&#x2F;script&gt;"/><meta name="viewport" content="width=device-width"/><link rel="stylesheet" href="css&#x2F;screen.css"/></head><body><h1>OMG HAI LOL</h1><p>This is clearly the best HTML DSL ever invented.&lt;script&gt;alert(&quot;lol pwned&quot;);&lt;&#x2F;script&gt;</p></body></html>"""
+expected = """<html lang="en"><head><meta charset="utf-8"/><meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/><title>OMG HAI LOL</title><meta name="description" content="YES OMG HAI LOL&quot;&gt;&lt;script&gt;alert(&quot;lol pwned&quot;);&lt;&#x2F;script&gt;"/><meta name="viewport" content="width=device-width"/><link rel="stylesheet" href="css&#x2F;screen.css"/><script src="index.js"></script></head><body><h1>OMG HAI LOL</h1><p>This is clearly the best HTML DSL ever invented.&lt;script&gt;alert(&quot;lol pwned&quot;);&lt;&#x2F;script&gt;</p></body></html>"""
 
 main :: Eff (console :: CONSOLE, avar :: AVAR, testOutput :: TESTOUTPUT) Unit
 main = runTest do


### PR DESCRIPTION
This is implemented in slightly over engineered way using a finite stream (`Cofree Maybe Char`).

Does not escape numeric and named entities.
This does not check if the entity is valid so it may render invalid HTML
string, e.g. `<div>&#1;</div>` or `<div>&abc;</div>`.

I pushed on top of #30. 

It solves #20 at least to some extend.