### PR TITLE
empty markup instead of monoid's mempty

### DIFF
--- a/src/Text/Smolder/Markup.purs
+++ b/src/Text/Smolder/Markup.purs
@@ -70,6 +70,10 @@ leaf el = liftF $ Element el (liftF $ Empty unit) mempty mempty unit
 text :: ∀ e. String → Markup e
 text s = liftF $ Content s unit
 
+-- | Used for empty nodes (without text or children)
+empty :: ∀ e. Markup e
+empty = liftF $ Empty unit
+
 data Attribute = Attribute (CatList Attr)
 
 instance semigroupAttribute :: Semigroup Attribute where


### PR DESCRIPTION
When markup wasn't Free, there was a convenient Monoid, so that 
```purescript
div ! className "empty" $ mempty
```
was giving a
```html
<div class="empty"></div>
```

I suggest this small amendment instead, so that

```purescript
div ! className "empty" $ empty
```
renders to the same HTML output