### PR TITLE
Ensure link tag type attrs are not escaped

### DIFF
--- a/src/Text/Smolder/Renderer/String.purs
+++ b/src/Text/Smolder/Renderer/String.purs
@@ -41,10 +41,11 @@ isMIMEAttr tag attr
   | attr == "type" && tag == "script" = true
   | attr == "type" && tag == "source" = true
   | attr == "type" && tag == "style" = true
+  | attr == "type" && tag == "link" = true
   | otherwise = false
 
 -- url attributes according to:
--- https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes 
+-- https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes
 isURLAttr :: String -> String -> Boolean
 isURLAttr tag attr
   | attr == "href" && tag == "a" = true

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -23,7 +23,7 @@ doc = html ! lang "en" $ do
     title $ text "OMG HAI LOL"
     meta ! name "description" ! content "YES OMG HAI LOL\"><script>alert(\"lol pwned\");</script>"
     meta ! name "viewport" ! content "width=device-width"
-    link ! rel "stylesheet" ! href "css/screen.css"
+    link ! type' "text/css" ! rel "stylesheet" ! href "css/screen.css"
     style ! type' "text/css" $ text " "
   body $ do
     h1 #! on "click" (\_ -> log "click") $ text "OMG HAI LOL"
@@ -31,7 +31,7 @@ doc = html ! lang "en" $ do
     p $ text "This is clearly the best HTML DSL ever invented.<script>alert(\"lol pwned\");</script>"
 
 expected :: String
-expected = """<html lang="en"><head><meta charset="utf-8"/><meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/><title>OMG HAI LOL</title><meta name="description" content="YES OMG HAI LOL&quot;&gt;&lt;script&gt;alert(&quot;lol pwned&quot;);&lt;&#x2F;script&gt;"/><meta name="viewport" content="width=device-width"/><link rel="stylesheet" href="css/screen.css"/><style type="text/css"> </style></head><body><h1>OMG HAI LOL</h1><img src="images/img.png?id=123&a=true"/><p>This is clearly the best HTML DSL ever invented.&lt;script&gt;alert(&quot;lol pwned&quot;);&lt;&#x2F;script&gt;</p></body></html>"""
+expected = """<html lang="en"><head><meta charset="utf-8"/><meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/><title>OMG HAI LOL</title><meta name="description" content="YES OMG HAI LOL&quot;&gt;&lt;script&gt;alert(&quot;lol pwned&quot;);&lt;&#x2F;script&gt;"/><meta name="viewport" content="width=device-width"/><link type="text/css" rel="stylesheet" href="css/screen.css"/><style type="text/css"> </style></head><body><h1>OMG HAI LOL</h1><img src="images/img.png?id=123&a=true"/><p>This is clearly the best HTML DSL ever invented.&lt;script&gt;alert(&quot;lol pwned&quot;);&lt;&#x2F;script&gt;</p></body></html>"""
 
 main :: Eff (console :: CONSOLE, avar :: AVAR, testOutput :: TESTOUTPUT) Unit
 main = runTest do


### PR DESCRIPTION
Maybe I'm just old and we don't need MIME type on link tags anymore, but if we do, this will fix the extra escaping that's going on.

Before:
`<link rel="stylesheet" type="text&#x2F;css" href="style.css"/>`

After:
`<link rel="stylesheet" type="text/css" href="style.css"/>`

(See https://github.com/bodil/purescript-smolder/issues/25)

Thanks!