### PR TITLE
Add empty to exports

### DIFF
--- a/src/Text/Smolder/Markup.purs
+++ b/src/Text/Smolder/Markup.purs
@@ -7,6 +7,7 @@ module Text.Smolder.Markup
   , parent
   , leaf
   , text
+  , empty
   , Attribute()
   , class Attributable
   , with


### PR DESCRIPTION
This is in reference to #33 - `empty` isn't exposed by the module, so it can't be used.