### PR TITLE
Updates for purescript compiler v0.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ bulletList = ul $ do
 Use the `#!` combinator to attach event handlers:
 
 ```purescript
-import Control.Monad.Eff.Console (log)
+import Effect.Class.Console (log)
 
 doc = div ! className "not-a-form" $ do
   button #! on "click" (\event → log "boom!") $ text "boom"

--- a/bower.json
+++ b/bower.json
@@ -18,17 +18,16 @@
     "output"
   ],
   "dependencies": {
-    "purescript-monoid": "^3.0.0",
-    "purescript-maps": "^3.0.0",
-    "purescript-strings": "^3.0.0",
-    "purescript-catenable-lists": "^4.0.0",
-    "purescript-tuples": "^4.0.0",
-    "purescript-free": "^4.1.0",
-    "purescript-transformers": "^3.4.0",
-    "purescript-bifunctors": "^3.0.0",
-    "purescript-globals": "^3.0.0"
+    "purescript-bifunctors": "^4.0.0",
+    "purescript-catenable-lists": "^5.0.0",
+    "purescript-free": "^5.0.0",
+    "purescript-globals": "^4.0.0",
+    "purescript-ordered-collections": "^1.0.0",
+    "purescript-strings": "^4.0.0",
+    "purescript-transformers": "^4.1.0",
+    "purescript-tuples": "^5.0.0"
   },
   "devDependencies": {
-    "purescript-test-unit": "^11.0.0"
+    "purescript-test-unit": "^14.0.0"
   }
 }

--- a/psc-package.json
+++ b/psc-package.json
@@ -1,14 +1,17 @@
 {
     "name": "purescript-smolder",
-    "set": "psc-0.11.7",
+    "set": "psc-0.12.0",
     "source": "https://github.com/purescript/package-sets.git",
     "depends": [
-        "tuples",
+        "bifunctors",
         "catenable-lists",
+        "free",
+        "globals",
+        "ordered-collections",
+        "prelude",
         "strings",
-        "maps",
-        "monoid",
         "test-unit",
-        "prelude"
+        "transformers",
+        "tuples"
     ]
 }

--- a/src/Text/Smolder/Markup.purs
+++ b/src/Text/Smolder/Markup.purs
@@ -27,7 +27,6 @@ import Prelude
 import Control.Monad.Free (Free, foldFree, hoistFree, liftF)
 import Data.Bifunctor (class Bifunctor, lmap)
 import Data.CatList (CatList)
-import Data.Monoid (class Monoid, mempty)
 
 data Attr = Attr String String
 

--- a/src/Text/Smolder/Renderer/String.purs
+++ b/src/Text/Smolder/Renderer/String.purs
@@ -9,14 +9,14 @@ import Control.Monad.State (execState, State, state)
 import Data.CatList (CatList)
 import Data.Foldable (fold)
 import Data.Maybe (fromMaybe)
-import Data.StrMap (StrMap, fromFoldable, lookup)
+import Data.Map (Map, fromFoldable, lookup)
 import Data.String (Pattern(Pattern), joinWith, length, split)
 import Data.Tuple (Tuple(..))
 import Data.Tuple.Nested ((/\))
-import Global (encodeURI)
+import Global.Unsafe (unsafeEncodeURI)
 import Text.Smolder.Markup (Attr(..), Markup, MarkupM(..))
 
-escapeMap :: StrMap String
+escapeMap :: Map String String
 escapeMap = fromFoldable
   [ "&" /\ "&amp;"
   , "<" /\ "&lt;"
@@ -26,7 +26,7 @@ escapeMap = fromFoldable
   , "/" /\ "&#x2F;"
   ]
 
-escapeMIMEMap :: StrMap String
+escapeMIMEMap :: Map String String
 escapeMIMEMap = fromFoldable
   [ "&" /\ "&amp;"
   , "<" /\ "&lt;"
@@ -44,7 +44,7 @@ isMIMEAttr tag attr
   | otherwise = false
 
 -- url attributes according to:
--- https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes 
+-- https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes
 isURLAttr :: String -> String -> Boolean
 isURLAttr tag attr
   | attr == "href" && tag == "a" = true
@@ -67,7 +67,7 @@ isURLAttr tag attr
   | attr == "poster" && tag == "video" = true
   | otherwise = false
 
-escape :: StrMap String -> String -> String
+escape :: Map String String -> String -> String
 escape m s = joinWith "" (escapeChar <$> (split (Pattern "") s))
   where
     escapeChar :: String -> String
@@ -75,7 +75,7 @@ escape m s = joinWith "" (escapeChar <$> (split (Pattern "") s))
 
 escapeAttrValue :: String -> String -> String -> String
 escapeAttrValue tag key value
-  | isURLAttr tag key   = encodeURI value
+  | isURLAttr tag key   = unsafeEncodeURI value
   | isMIMEAttr tag key  = escape escapeMIMEMap value
   | otherwise           = escape escapeMap value
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -2,20 +2,18 @@ module Test.Main where
 
 import Prelude
 
-import Control.Monad.Aff.AVar (AVAR)
-import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Console (CONSOLE, log)
+import Effect (Effect)
+import Effect.Class.Console (log)
 import Test.SVG as SvgTest
 import Test.Unit (test)
 import Test.Unit.Assert (equal)
-import Test.Unit.Console (TESTOUTPUT)
 import Test.Unit.Main (runTest)
 import Text.Smolder.HTML (body, h1, head, html, img, link, meta, p, style, title)
 import Text.Smolder.HTML.Attributes (charset, content, href, httpEquiv, lang, name, rel, src, type')
-import Text.Smolder.Markup (on, (#!), Markup, text, (!))
+import Text.Smolder.Markup (Markup, on, text, (!), (#!))
 import Text.Smolder.Renderer.String (render)
 
-doc :: forall a e. Markup (a -> Eff (console :: CONSOLE | e) Unit)
+doc :: forall a. Markup (a -> Effect Unit)
 doc = html ! lang "en" $ do
   head $ do
     meta ! charset "utf-8"
@@ -33,8 +31,9 @@ doc = html ! lang "en" $ do
 expected :: String
 expected = """<html lang="en"><head><meta charset="utf-8"/><meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/><title>OMG HAI LOL</title><meta name="description" content="YES OMG HAI LOL&quot;&gt;&lt;script&gt;alert(&quot;lol pwned&quot;);&lt;&#x2F;script&gt;"/><meta name="viewport" content="width=device-width"/><link rel="stylesheet" href="css/screen.css"/><style type="text/css"> </style></head><body><h1>OMG HAI LOL</h1><img src="images/img.png?id=123&a=true"/><p>This is clearly the best HTML DSL ever invented.&lt;script&gt;alert(&quot;lol pwned&quot;);&lt;&#x2F;script&gt;</p></body></html>"""
 
-main :: Eff (console :: CONSOLE, avar :: AVAR, testOutput :: TESTOUTPUT) Unit
-main = runTest do
-  test "render HTML to string" do
-    equal expected $ render doc
-  SvgTest.tests
+main :: Effect Unit
+main =
+  runTest do
+    test "render HTML to string" do
+      equal expected $ render doc
+    SvgTest.tests

--- a/test/SVG.purs
+++ b/test/SVG.purs
@@ -1,16 +1,15 @@
 module Test.SVG where
 
 import Prelude
-import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Console (CONSOLE)
+
 import Test.Unit (TestSuite, test)
 import Test.Unit.Assert (equal)
-import Text.Smolder.SVG (svg, g, rect, circle)
-import Text.Smolder.SVG.Attributes (width, height, x, y, fill, cx, cy, r)
 import Text.Smolder.Markup (Markup, (!))
 import Text.Smolder.Renderer.String (render)
+import Text.Smolder.SVG (svg, g, rect, circle)
+import Text.Smolder.SVG.Attributes (width, height, x, y, fill, cx, cy, r)
 
-img :: forall a e. Markup (a -> Eff (console :: CONSOLE | e) Unit)
+img :: forall a. Markup a
 img = svg ! width "300" ! height "250" $ do
   g $ do
     rect ! x "0" ! y "200" ! width "20" ! height "50" ! fill "blue"
@@ -23,7 +22,7 @@ img = svg ! width "300" ! height "250" $ do
 expected :: String
 expected = """<svg width="300" height="250"><g><rect x="0" y="200" width="20" height="50" fill="blue"/><rect x="20" y="200" width="20" height="50" fill="blue"/><rect x="40" y="200" width="20" height="50" fill="blue"/><rect x="60" y="200" width="20" height="50" fill="blue"/></g><g><circle cx="100" cy="100" r="10" fill="red"/></g></svg>"""
 
-tests :: ∀ e. TestSuite e
+tests :: TestSuite
 tests =
   test "render SVG to string" do
     equal expected $ render img


### PR DESCRIPTION
- update psc-package set to v0.12.0 tag
- add missing packages to psc-package.json
- update bower.json to match psc-package sets
- updated deprecated data structures (`s/StrMap a/Map String a/g`)
- remove effect rows in favor of `Effect` (needed for v0.12.0)