### PR TITLE
Do not self-close empty divs

### DIFF
--- a/src/Text/Smolder/Markup.purs
+++ b/src/Text/Smolder/Markup.purs
@@ -31,6 +31,8 @@ import Data.CatList (CatList)
 
 data NS = HTMLns | SVGns
 
+derive instance eqNS :: Eq NS
+
 data Attr = Attr String String
 
 data EventHandler e = EventHandler String e

--- a/src/Text/Smolder/SVG.purs
+++ b/src/Text/Smolder/SVG.purs
@@ -199,4 +199,3 @@ view :: forall e. Markup e -> Markup e
 view = parent "view"
 vkern :: forall e. Markup e -> Markup e
 vkern = parent "vkern"
-

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -10,7 +10,7 @@ import Test.Unit.Assert (equal)
 import Test.Unit.Main (runTest)
 import Text.Smolder.HTML (body, div, h1, head, html, img, link, meta, p, script, style, title)
 import Text.Smolder.HTML.Attributes (charset, content, href, httpEquiv, lang, name, rel, src, type')
-import Text.Smolder.Markup (Markup, on, text, (!), (#!))
+import Text.Smolder.Markup (Markup, empty, on, text, (!), (#!))
 import Text.Smolder.Renderer.String (render)
 
 doc :: forall a. Markup (a -> Effect Unit)
@@ -28,9 +28,10 @@ doc = html ! lang "en" $ do
     h1 #! on "click" (\_ -> log "click") $ text "OMG HAI LOL"
     img ! src "images/img.png?id=123&a=true"
     p $ text "This is clearly the best HTML DSL ever invented.<script>alert(\"lol pwned\");</script>"
+    div $ empty
 
 expected :: String
-expected = """<html lang="en"><head><meta charset="utf-8"/><meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/><title>OMG HAI LOL</title><meta name="description" content="YES OMG HAI LOL&quot;&gt;&lt;script&gt;alert(&quot;lol pwned&quot;);&lt;&#x2F;script&gt;"/><meta name="viewport" content="width=device-width"/><link rel="stylesheet" href="css/screen.css"/><script src="index.js"></script><style type="text/css"> </style></head><body><h1>OMG HAI LOL</h1><img src="images/img.png?id=123&a=true"/><p>This is clearly the best HTML DSL ever invented.&lt;script&gt;alert(&quot;lol pwned&quot;);&lt;&#x2F;script&gt;</p></body></html>"""
+expected = """<html lang="en"><head><meta charset="utf-8"/><meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/><title>OMG HAI LOL</title><meta name="description" content="YES OMG HAI LOL&quot;&gt;&lt;script&gt;alert(&quot;lol pwned&quot;);&lt;&#x2F;script&gt;"/><meta name="viewport" content="width=device-width"/><link rel="stylesheet" href="css/screen.css"/><script src="index.js"></script><style type="text/css"> </style></head><body><h1>OMG HAI LOL</h1><img src="images/img.png?id=123&a=true"/><p>This is clearly the best HTML DSL ever invented.&lt;script&gt;alert(&quot;lol pwned&quot;);&lt;&#x2F;script&gt;</p><div></div></body></html>"""
 
 main :: Effect Unit
 main = runTest do


### PR DESCRIPTION
Empty `div` tags should not self-close. This was causing issues when rendering some of my pages.