### PR TITLE
Add support for DOCTYPE

### DIFF
--- a/src/Text/Smolder/Markup.purs
+++ b/src/Text/Smolder/Markup.purs
@@ -9,6 +9,7 @@ module Text.Smolder.Markup
   , leaf
   , text
   , empty
+  , doctype
   , Attribute()
   , class Attributable
   , with
@@ -41,10 +42,12 @@ instance functorEventHandler ∷ Functor EventHandler where
 -- | Representation of a markup node.
 -- |
 -- | This is either an `Element`, which maps to a DOM element,
--- | a `Content` node, which maps to a DOM text node, or `Empty`,
--- | which maps to an empty `NodeList`.
+-- | a `Content` node, which maps to a DOM text node, a `Doctype`
+-- | which maps to a DOCTYPE declaration, or `Empty`, which maps
+-- | to an empty `NodeList`.
 data MarkupM e a
   = Element NS String (Markup e) (CatList Attr) (CatList (EventHandler e)) a
+  | Doctype String a
   | Content String a
   | Empty a
 
@@ -54,6 +57,7 @@ type Markup e = Free (MarkupM e) Unit
 instance bifunctorMarkupM :: Bifunctor MarkupM where
   bimap l r (Empty a) = Empty (r a)
   bimap l r (Content t a) = Content t (r a)
+  bimap l r (Doctype t a) = Doctype t (r a)
   bimap l r (Element ns el kids attrs events a) =
     Element ns el (mapEvent l kids) attrs (map l <$> events) (r a)
 
@@ -76,6 +80,10 @@ text s = liftF $ Content s unit
 -- | Used for empty nodes (without text or children)
 empty :: ∀ e. Markup e
 empty = liftF $ Empty unit
+
+-- | Used for doctype
+doctype :: ∀ e. String → Markup e
+doctype s = liftF $ Doctype s unit
 
 data Attribute = Attribute (CatList Attr)
 

--- a/src/Text/Smolder/Renderer/String.purs
+++ b/src/Text/Smolder/Renderer/String.purs
@@ -140,6 +140,7 @@ renderItem (Element _ name children attrs _ rest) =
            else "/>")
   in state \s → Tuple rest $ append s b
 renderItem (Content text rest) = state \s → Tuple rest $ append s $ escape escapeMap text
+renderItem (Doctype text rest) = state \s → Tuple rest $ append s $ "<!DOCTYPE " <> text <> ">"
 renderItem (Empty rest) = pure rest
 
 -- | Render markup as an HTML string.

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -10,27 +10,30 @@ import Test.Unit.Assert (equal)
 import Test.Unit.Main (runTest)
 import Text.Smolder.HTML (body, div, h1, head, html, img, link, meta, p, script, style, title)
 import Text.Smolder.HTML.Attributes (charset, content, href, httpEquiv, lang, name, rel, src, type')
-import Text.Smolder.Markup (Markup, on, text, (!), (#!))
+import Text.Smolder.Markup (Markup, doctype, on, text, (!), (#!))
 import Text.Smolder.Renderer.String (render)
 
 doc :: forall a. Markup (a -> Effect Unit)
-doc = html ! lang "en" $ do
-  head $ do
-    meta ! charset "utf-8"
-    meta ! httpEquiv "X-UA-Compatible" ! content "IE=edge,chrome=1"
-    title $ text "OMG HAI LOL"
-    meta ! name "description" ! content "YES OMG HAI LOL\"><script>alert(\"lol pwned\");</script>"
-    meta ! name "viewport" ! content "width=device-width"
-    link ! rel "stylesheet" ! href "css/screen.css"
-    script ! src "index.js" $ text ""
-    style ! type' "text/css" $ text " "
-  body $ do
-    h1 #! on "click" (\_ -> log "click") $ text "OMG HAI LOL"
-    img ! src "images/img.png?id=123&a=true"
-    p $ text "This is clearly the best HTML DSL ever invented.<script>alert(\"lol pwned\");</script>"
+doc = do
+  doctype "html"
+
+  html ! lang "en" $ do
+    head $ do
+      meta ! charset "utf-8"
+      meta ! httpEquiv "X-UA-Compatible" ! content "IE=edge,chrome=1"
+      title $ text "OMG HAI LOL"
+      meta ! name "description" ! content "YES OMG HAI LOL\"><script>alert(\"lol pwned\");</script>"
+      meta ! name "viewport" ! content "width=device-width"
+      link ! rel "stylesheet" ! href "css/screen.css"
+      script ! src "index.js" $ text ""
+      style ! type' "text/css" $ text " "
+    body $ do
+      h1 #! on "click" (\_ -> log "click") $ text "OMG HAI LOL"
+      img ! src "images/img.png?id=123&a=true"
+      p $ text "This is clearly the best HTML DSL ever invented.<script>alert(\"lol pwned\");</script>"
 
 expected :: String
-expected = """<html lang="en"><head><meta charset="utf-8"/><meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/><title>OMG HAI LOL</title><meta name="description" content="YES OMG HAI LOL&quot;&gt;&lt;script&gt;alert(&quot;lol pwned&quot;);&lt;&#x2F;script&gt;"/><meta name="viewport" content="width=device-width"/><link rel="stylesheet" href="css/screen.css"/><script src="index.js"></script><style type="text/css"> </style></head><body><h1>OMG HAI LOL</h1><img src="images/img.png?id=123&a=true"/><p>This is clearly the best HTML DSL ever invented.&lt;script&gt;alert(&quot;lol pwned&quot;);&lt;&#x2F;script&gt;</p></body></html>"""
+expected = """<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"/><meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/><title>OMG HAI LOL</title><meta name="description" content="YES OMG HAI LOL&quot;&gt;&lt;script&gt;alert(&quot;lol pwned&quot;);&lt;&#x2F;script&gt;"/><meta name="viewport" content="width=device-width"/><link rel="stylesheet" href="css/screen.css"/><script src="index.js"></script><style type="text/css"> </style></head><body><h1>OMG HAI LOL</h1><img src="images/img.png?id=123&a=true"/><p>This is clearly the best HTML DSL ever invented.&lt;script&gt;alert(&quot;lol pwned&quot;);&lt;&#x2F;script&gt;</p></body></html>"""
 
 main :: Effect Unit
 main = runTest do


### PR DESCRIPTION
This PR adds support for the [DOCTYPE](https://en.wikipedia.org/wiki/Document_type_declaration) declaration.

Because it does not close like all other HTML tags, I chose to model DOCTYPE using a new constructor of `MarkupM`. Please let me know if this makes sense.

Also, I chose to model the "body" of the DOCTYPE as a simple string. While there is an internal structure to the declaration, most applications simply use the HTML5 style:

```<!DOCTYPE html>```

In cases where the more complicated style is preferred, the body of the DOCTYPE can be provided as a raw string.