### PR TITLE
Add support for safe attributes

### DIFF
--- a/src/Text/Smolder/Markup.purs
+++ b/src/Text/Smolder/Markup.purs
@@ -14,6 +14,7 @@ module Text.Smolder.Markup
   , class Attributable
   , with
   , attribute
+  , safe
   , (!)
   , optionalWith
   , (!?)
@@ -34,7 +35,9 @@ data NS = HTMLns | SVGns
 
 derive instance eqNS :: Eq NS
 
-data Attr = Attr String String
+data Attr
+  = Attr String String
+  | SafeAttr String String
 
 data EventHandler e = EventHandler String e
 
@@ -98,6 +101,13 @@ instance monoidAttribute :: Monoid Attribute where
 -- | Create an attribute.
 attribute :: String → String → Attribute
 attribute key value = Attribute (pure $ Attr key value)
+
+safe :: Attribute → Attribute
+safe (Attribute attrs) = Attribute $ map safeAttr attrs
+  where
+    safeAttr :: Attr → Attr
+    safeAttr attr@(SafeAttr _ _) = attr
+    safeAttr (Attr key val) = SafeAttr key val
 
 class Attributable a where
   -- | Add an attribute to a markup node.

--- a/src/Text/Smolder/Renderer/String.purs
+++ b/src/Text/Smolder/Renderer/String.purs
@@ -16,8 +16,8 @@ import Data.Map (Map, lookup, fromFoldable)
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Set (Set)
 import Data.Set as Set
-import Data.String.CodeUnits (fromCharArray, toCharArray)
 import Data.String (length)
+import Data.String.CodeUnits (fromCharArray, toCharArray)
 import Data.Tuple (Tuple(..))
 import Data.Tuple.Nested ((/\))
 import Global.Unsafe (unsafeEncodeURI)
@@ -147,11 +147,13 @@ escapeAttrValue tag key value
 
 showAttrs :: String -> CatList Attr → String
 showAttrs tag = map showAttr >>> fold
-  where showAttr (Attr key value) = " "
-          <> key
-          <> "=\""
-          <> escapeAttrValue tag key value
-          <> "\""
+  where
+    showAttr (SafeAttr key value) = " " <> key <> "=\"" <> value <> "\""
+    showAttr (Attr key value) = " "
+      <> key
+      <> "=\""
+      <> escapeAttrValue tag key value
+      <> "\""
 
 voidTags :: Array String
 voidTags = ["area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param", "source", "track", "wbr"]

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -8,9 +8,9 @@ import Test.SVG as SvgTest
 import Test.Unit (suite, test)
 import Test.Unit.Assert (equal)
 import Test.Unit.Main (runTest)
-import Text.Smolder.HTML (body, div, h1, head, html, img, link, meta, p, script, style, title)
-import Text.Smolder.HTML.Attributes (charset, content, href, httpEquiv, lang, name, rel, src, type')
-import Text.Smolder.Markup (Markup, doctype, empty, on, text, (!), (#!))
+import Text.Smolder.HTML (body, div, form, h1, head, html, img, link, meta, p, script, style, title)
+import Text.Smolder.HTML.Attributes (action, charset, content, href, httpEquiv, lang, name, rel, src, type')
+import Text.Smolder.Markup (Markup, doctype, empty, on, safe, text, (!), (#!))
 import Text.Smolder.Renderer.String (render)
 
 doc :: forall a. Markup (a -> Effect Unit)
@@ -50,6 +50,8 @@ main = runTest do
       equal "<div>&amp;gt.</div>" $ render $ div $ text "&gt."
       equal "<div>&amp;#.</div>" $ render $ div $ text "&#."
       equal "<div>&amp;#;</div>" $ render $ div $ text "&#;"
+    test "doesn't escape safe attributes" do
+      equal "<form action=\"/foo/bar\"></form>" $ render $ form ! (safe $ action "/foo/bar") $ empty
     test "quirks" do
       -- this renders invalid HTML
       equal "<div>&#1;</div>" $ render $ div $ text "&#1;"


### PR DESCRIPTION
The `safe` function allows creating attributes with values that will not be escaped during rendering.

I'm not sure if there's a more-clever way to add safety via a phantom type, but adding a new `Attr` constructor seems to work just fine.

Fixes #39 