### PR TITLE
fix 'globals' dependencie and add spago file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,8 @@
 *.tix
 /.psc-package
 /.pulp-cache
-.psc-ide-port
+/generated-docs/
+/.psc*
+/.purs*
+/.psa*
+/.spago

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,0 +1,104 @@
+{-
+Welcome to your new Dhall package-set!
+
+Below are instructions for how to edit this file for most use
+cases, so that you don't need to know Dhall to use it.
+
+## Use Cases
+
+Most will want to do one or both of these options:
+1. Override/Patch a package's dependency
+2. Add a package not already in the default package set
+
+This file will continue to work whether you use one or both options.
+Instructions for each option are explained below.
+
+### Overriding/Patching a package
+
+Purpose:
+- Change a package's dependency to a newer/older release than the
+    default package set's release
+- Use your own modified version of some dependency that may
+    include new API, changed API, removed API by
+    using your custom git repo of the library rather than
+    the package set's repo
+
+Syntax:
+where `entityName` is one of the following:
+- dependencies
+- repo
+- version
+-------------------------------
+let upstream = --
+in  upstream
+  with packageName.entityName = "new value"
+-------------------------------
+
+Example:
+-------------------------------
+let upstream = --
+in  upstream
+  with halogen.version = "master"
+  with halogen.repo = "https://example.com/path/to/git/repo.git"
+
+  with halogen-vdom.version = "v4.0.0"
+  with halogen-vdom.dependencies = [ "extra-dependency" ] # halogen-vdom.dependencies
+-------------------------------
+
+### Additions
+
+Purpose:
+- Add packages that aren't already included in the default package set
+
+Syntax:
+where `<version>` is:
+- a tag (i.e. "v4.0.0")
+- a branch (i.e. "master")
+- commit hash (i.e. "701f3e44aafb1a6459281714858fadf2c4c2a977")
+-------------------------------
+let upstream = --
+in  upstream
+  with new-package-name =
+    { dependencies =
+       [ "dependency1"
+       , "dependency2"
+       ]
+    , repo =
+       "https://example.com/path/to/git/repo.git"
+    , version =
+        "<version>"
+    }
+-------------------------------
+
+Example:
+-------------------------------
+let upstream = --
+in  upstream
+  with benchotron =
+      { dependencies =
+          [ "arrays"
+          , "exists"
+          , "profunctor"
+          , "strings"
+          , "quickcheck"
+          , "lcg"
+          , "transformers"
+          , "foldable-traversable"
+          , "exceptions"
+          , "node-fs"
+          , "node-buffer"
+          , "node-readline"
+          , "datetime"
+          , "now"
+          ]
+      , repo =
+          "https://github.com/hdgarrood/purescript-benchotron.git"
+      , version =
+          "v7.0.0"
+      }
+-------------------------------
+-}
+let upstream =
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.4-20210826/packages.dhall sha256:eee0765aa98e0da8fc414768870ad588e7cada060f9f7c23c37385c169f74d9f
+
+in  upstream

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,0 +1,35 @@
+{-
+Welcome to a Spago project!
+You can edit this file as you like.
+
+Need help? See the following resources:
+- Spago documentation: https://github.com/purescript/spago
+- Dhall language tour: https://docs.dhall-lang.org/tutorials/Language-Tour.html
+
+When creating a new Spago project, you can use
+`spago init --no-comments` or `spago init -C`
+to generate this file without the comments in this block.
+-}
+{ name = "purescript-smolder"
+, dependencies = [
+    "console"
+    , "effect"
+    , "prelude"
+    , "psci-support"
+    , "bifunctors"
+    , "catenable-lists"
+    , "free"
+    , "ordered-collections"
+    , "prelude"
+    , "strings"
+    , "test-unit"
+    , "transformers"
+    , "tuples"
+    , "arrays"
+    , "control"
+    , "foldable-traversable"
+    , "maybe"
+]
+, packages = ./packages.dhall
+, sources = [ "src/**/*.purs", "test/**/*.purs" ]
+}

--- a/src/Text/Smolder/Renderer/String.purs
+++ b/src/Text/Smolder/Renderer/String.purs
@@ -20,7 +20,7 @@ import Data.String (length)
 import Data.String.CodeUnits (fromCharArray, toCharArray)
 import Data.Tuple (Tuple(..))
 import Data.Tuple.Nested ((/\))
-import Global.Unsafe (unsafeEncodeURI)
+import Text.Smolder.URI (unsafeEncodeURI)
 import Text.Smolder.Markup (Attr(..), Markup, MarkupM(..), NS(..))
 
 escapeMap :: Map Char String

--- a/src/Text/Smolder/URI/EncodeUri.js
+++ b/src/Text/Smolder/URI/EncodeUri.js
@@ -1,0 +1,1 @@
+exports.unsafeEncodeURI = encodeURI;

--- a/src/Text/Smolder/URI/EncodeUri.purs
+++ b/src/Text/Smolder/URI/EncodeUri.purs
@@ -1,0 +1,3 @@
+module Text.Smolder.URI where
+
+foreign import unsafeEncodeURI :: String -> String


### PR DESCRIPTION
I am studying this aspect, if I am doing something wrong, please let me know.

I noticed that the [global](https://pursuit.purescript.org/packages/purescript-globals/5.0.0) library has been deprecated and split into multiple libraries.
I didn't find where 'EncodeURI' is (there is only'encodeURIComponent' in [purescript-js-uri](https://github.com/purescript-contrib/purescript-js-uri)), so I wrote this function myself.
In addition, I added the [spago](https://github.com/purescript/spago) file to facilitate the installation using spago.
Now, using 'spago build' and 'spago test', everything looks normal.

Can you add it to [package-sets](https://github.com/purescript/package-sets)?